### PR TITLE
Added cross-repo support

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,12 @@ branding:
   icon: 'lock'
   color: 'blue'
 inputs:
+  token:
+    description: >
+      The token to access the repository if an external repository is used to manage locks.
+      Optional: if the repository that triggered the workflow is used but must be supplied 
+      if locks should be held in an external repository.
+    required: false
   locks_dir:
     description: >
       Directory to store the lock file. 

--- a/src/acquire-lock.js
+++ b/src/acquire-lock.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import * as github from "@actions/github";
+import * as core from "@actions/core";
 import {
   checkBranchExists,
   runGit,
@@ -16,11 +17,11 @@ export async function acquireLock(lockFile, locksBranch) {
   while (retries < maxRetries) {
     const exists = await checkBranchExists(locksBranch);
     if (exists) {
-      console.log("Branch exists → fetching and switching");
+      core.info("Branch exists → fetching and switching");
       await runGit(["fetch", "origin", locksBranch]);
       await runGit(["checkout", locksBranch]);
     } else {
-      console.log("Branch does not exist → creating orphan branch");
+      core.info("Branch does not exist → creating orphan branch");
       await runGit(["checkout", "--orphan", locksBranch]);
       await runGit(["rm", "-rf", "."]);
     }
@@ -51,12 +52,12 @@ export async function acquireLock(lockFile, locksBranch) {
       () => false
     );
     if (pushed) {
-      console.log("Lock acquired successfully!");
+      core.info("Lock acquired successfully!");
       return;
     }
 
     retries++;
-    console.log(
+    core.warning(
       `Push failed — another workflow may have modified the lock. Retrying ${retries}/${maxRetries} in ${retryDelay}ms...`
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import { exec } from "@actions/exec";
 import { acquireLock } from "./acquire-lock.js";
 import { releaseLock } from "./release-lock.js";
 import { waitForLock } from "./wait-lock.js";
+import { configureGit } from "./helpers.js";
 
 async function run() {
   try {
@@ -28,12 +28,9 @@ async function run() {
     const actionType = core.getInput("action");
     if (!actionType) throw new Error("Input 'action' is required");
 
-    await exec("git", ["config", "user.name", github.context.actor]);
-    await exec("git", [
-      "config",
-      "user.email",
-      `${github.context.actor}@users.noreply.github.com`,
-    ]);
+    const token = core.getInput("token");
+    const actor = github.context.actor;
+    await configureGit(token, actor);
 
     switch (actionType) {
       case "acquire":

--- a/src/release-lock.js
+++ b/src/release-lock.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import * as github from "@actions/github";
+import * as core from "@actions/core";
 import { runGit, checkBranchExists } from "./helpers.js";
 
 export async function releaseLock(lockFile, locksBranch) {
@@ -10,7 +11,7 @@ export async function releaseLock(lockFile, locksBranch) {
   while (retries < maxRetries) {
     const exists = await checkBranchExists(locksBranch);
     if (!exists) {
-      console.log("Branch does not exist, nothing to release");
+      core.notice("Branch does not exist, nothing to release");
       return;
     }
 
@@ -19,7 +20,7 @@ export async function releaseLock(lockFile, locksBranch) {
     await runGit(["reset", "--hard", `origin/${locksBranch}`]);
 
     if (!fs.existsSync(lockFile)) {
-      console.log("No lock file to release");
+      core.notice("No lock file to release");
       return;
     }
 
@@ -30,7 +31,7 @@ export async function releaseLock(lockFile, locksBranch) {
     const { sha } = github.context;
 
     if (!firstCommitSHA || firstCommitSHA !== sha) {
-      console.log("Lock is not owned by this commit, nothing to release");
+      core.notice("Lock is not owned by this commit, nothing to release");
       return;
     }
 
@@ -44,11 +45,11 @@ export async function releaseLock(lockFile, locksBranch) {
       () => false
     );
     if (pushed) {
-      console.log("Lock released successfully!");
+      core.info("Lock released successfully!");
       return;
     }
 
-    console.log("Push failed — retrying...");
+    core.warning("Push failed — retrying...");
     retries++;
 
     await new Promise((r) => setTimeout(r, retryDelay));

--- a/src/wait-lock.js
+++ b/src/wait-lock.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import * as github from "@actions/github";
+import * as core from "@actions/core";
 import { checkBranchExists, runGit } from "./helpers.js";
 
 export async function waitForLock(
@@ -32,10 +33,10 @@ export async function waitForLock(
     const { sha } = github.context;
 
     if (firstCommitSHA === sha) {
-      console.log("Lock confirmed! Proceeding...");
+      core.info("Lock confirmed! Proceeding...");
       return;
     } else {
-      console.log(
+      core.notice(
         `Lock held by another workflow (${firstCommitSHA}). Waiting...`
       );
       const delayInMilliSec = sleepInterval * 1000;


### PR DESCRIPTION
This PR adds cross-repo support to the Lock Queue - GitHub Action.

**Changes included:**

- Added the ability to acquire, release, and wait for locks in a different repository.
- Introduced an optional token input to authenticate against a cross-repo target.
- Updated configureGit to handle tokens and set the correct origin URL dynamically.
- Ensures existing functionality for same-repo locks remains unchanged.

**Motivation**

Previously, Lock Queue assumed the workflow was always running in the same repository. This update allows teams to manage locks in a centralized repository, enabling better control across multiple projects.